### PR TITLE
URI.unescape (as well as CGI) sureaddress response

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    conduit-sureaddress (0.0.2)
+    conduit-sureaddress (0.0.3)
       conduit (~> 0.6.0)
 
 GEM
@@ -141,6 +141,3 @@ DEPENDENCIES
   rspec
   rspec-its
   shoulda-matchers
-
-BUNDLED WITH
-   1.10.5

--- a/lib/conduit/sureaddress/parsers/base.rb
+++ b/lib/conduit/sureaddress/parsers/base.rb
@@ -11,7 +11,7 @@ module Conduit::Driver::Sureaddress
       attr_accessor :xml
 
       def initialize(xml, http_status = nil)
-        unescaped_xml = CGI.unescapeHTML(xml)
+        unescaped_xml = CGI.unescapeHTML(URI.unescape(xml))
         @xml = Nokogiri::XML(unescaped_xml).css('string AddressResponse').to_s
         @http_status = http_status || 200
       end

--- a/lib/conduit/sureaddress/version.rb
+++ b/lib/conduit/sureaddress/version.rb
@@ -1,5 +1,5 @@
 module Conduit
   module SureAddress
-    VERSION = '0.0.2'
+    VERSION = '0.0.3'
   end
 end


### PR DESCRIPTION
CGI.unescapeHTML correctly converted ```&gt;``` and ```&lt;``` but left alone url encoded values like %20 for a space.